### PR TITLE
Release 5.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Quick Edit
 
+## 5.2.2 - 2025-06-07
+- Adjust installation behavior to set a cookie in dev mode.
+  This ensures you don't have to log out and back in after installation.
+
 ## 5.2.1 - 2025-05-30
 - Fix issue with standalone preview link generation
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "A plugin that adds a cp edit url to the frontend.",
   "type": "craft-plugin",
   "license": "mit",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "support": {
     "email": "samuelreichor@gmail.com",
     "issues": "https://github.com/samuelreichor/craft-quick-edit/issues?state=open",

--- a/src/QuickEdit.php
+++ b/src/QuickEdit.php
@@ -6,7 +6,9 @@ use Craft;
 use craft\base\Model;
 use craft\base\Plugin;
 use craft\controllers\UsersController;
+use craft\events\PluginEvent;
 use craft\events\RegisterTemplateRootsEvent;
+use craft\services\Plugins;
 use craft\web\View;
 use samuelreichor\quickedit\helpers\Utils;
 use samuelreichor\quickedit\models\Settings;
@@ -74,6 +76,17 @@ class QuickEdit extends Plugin
             View::EVENT_REGISTER_SITE_TEMPLATE_ROOTS,
             function(RegisterTemplateRootsEvent $event) {
                 $event->roots['quick-edit'] = __DIR__ . '/templates';
+            }
+        );
+
+        /* Set cookie on local plugin installation, because you probably have admin rights.*/
+        Event::on(
+            Plugins::class,
+            Plugins::EVENT_AFTER_INSTALL_PLUGIN,
+            function(PluginEvent $event) {
+                if ($event->plugin === $this && Craft::$app->getConfig()->general->devMode) {
+                    $this->setLoggedInCookie();
+                }
             }
         );
 


### PR DESCRIPTION
- Adjust installation behavior to set a cookie in dev mode.
  This ensures you don't have to log out and back in after installation.